### PR TITLE
Pass StatusCode to RazorResponseNegotiator

### DIFF
--- a/src/Razor/RazorResponseNegotiator.cs
+++ b/src/Razor/RazorResponseNegotiator.cs
@@ -34,13 +34,13 @@ public class RazorResponseNegotiator : IResponseNegotiator
                 viewLocation += "/" + s[0].ToString().ToUpper() + s[Range.StartAt(1)];
             }
             
-            var result = Results.Extensions.RazorSlice(viewLocation, model);
+            var result = Results.Extensions.RazorSlice(viewLocation, model, res.StatusCode);
             await result.ExecuteAsync(res.HttpContext);
         }
         else
         {
             var viewLocation = "/Slices";
-            var result = Results.Extensions.RazorSlice(viewLocation + viewName!, model);
+            var result = Results.Extensions.RazorSlice(viewLocation + viewName!, model, res.StatusCode);
             await result.ExecuteAsync(res.HttpContext);
         }
        


### PR DESCRIPTION
While experimenting with the Razor Response Negotiator I noticed that the status code was always returning 200, which wasn't expected when I set a different status code. This small tweak fixed it.